### PR TITLE
Update to dotnet 6 / Jellyfin 10.8

### DIFF
--- a/Jellyfin.Plugin.SmartPlaylist/Jellyfin.Plugin.SmartPlaylist.csproj
+++ b/Jellyfin.Plugin.SmartPlaylist/Jellyfin.Plugin.SmartPlaylist.csproj
@@ -1,17 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>1.0.0.0</Version>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.7.0" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.8.1" />
   </ItemGroup>
-
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /y /d  &quot;$(TargetPath)&quot; &quot;C:\Users\Rob\Desktop\jellyfin-data\plugins&quot;" />
-  </Target>
 
 </Project>

--- a/Jellyfin.Plugin.SmartPlaylist/Plugin.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/Plugin.cs
@@ -5,7 +5,6 @@ using MediaBrowser.Common.Plugins;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
 
-
 namespace Jellyfin.Plugin.SmartPlaylist
 {
     public class Plugin : BasePlugin<BasePluginConfiguration>, IHasWebPages
@@ -13,7 +12,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
         public Plugin(
             IApplicationPaths applicationPaths,
             IXmlSerializer xmlSerializer
-            ) : base(applicationPaths, xmlSerializer)
+        ) : base(applicationPaths, xmlSerializer)
         {
             Instance = this;
         }
@@ -35,10 +34,8 @@ namespace Jellyfin.Plugin.SmartPlaylist
                 {
                     //Name = "smartplaylist.html",
                     //EmbeddedResourcePath = string.Format("{0}.Configuration.smartplaylist.html", GetType().Namespace),
-                    
                 }
             };
         }
-
     }
 }

--- a/Jellyfin.Plugin.SmartPlaylist/Properties/launchSettings.json
+++ b/Jellyfin.Plugin.SmartPlaylist/Properties/launchSettings.json
@@ -2,8 +2,10 @@
   "profiles": {
     "Jellyfin.Plugin.SmartPlaylist": {
       "commandName": "Executable",
-      "executablePath": "C:\\Users\\Rob\\source\\repos\\jellyfin\\Jellyfin.Server\\bin\\Debug\\netcoreapp3.1\\jellyfin.exe",
-      "commandLineArgs": "-w C:\\Users\\Rob\\source\\repos\\jellyfin-web\\dist\\ -d C:\\Users\\Rob\\Desktop\\jellyfin-data\\ -c C:\\Users\\Rob\\Desktop\\jellyfin-config\\ --noautorunwebapp"
+      "executablePath":
+        "C:\\Users\\Rob\\source\\repos\\jellyfin\\Jellyfin.Server\\bin\\Debug\\netcoreapp3.1\\jellyfin.exe",
+      "commandLineArgs":
+        "-w C:\\Users\\Rob\\source\\repos\\jellyfin-web\\dist\\ -d C:\\Users\\Rob\\Desktop\\jellyfin-data\\ -c C:\\Users\\Rob\\Desktop\\jellyfin-config\\ --noautorunwebapp"
     }
   }
 }

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Engine.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Engine.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using System.Linq.Expressions;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq.Expressions;
 using System.Text.RegularExpressions;
 
 namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
@@ -9,13 +9,12 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
     // This is taken entirely from https://stackoverflow.com/questions/6488034/how-to-implement-a-rule-engine
     public class Engine
     {
-        static System.Linq.Expressions.Expression BuildExpr<T>(Expression r, ParameterExpression param)
+        private static System.Linq.Expressions.Expression BuildExpr<T>(Expression r, ParameterExpression param)
         {
-            var left = MemberExpression.Property(param, r.MemberName);
-            var tProp = typeof(T).GetProperty(r.MemberName).PropertyType;
-            ExpressionType tBinary;
+            var left = System.Linq.Expressions.Expression.Property(param, r.MemberName);
+            var tProp = typeof(T).GetProperty(r.MemberName)?.PropertyType;
             // is the operator a known .NET operator?
-            if (ExpressionType.TryParse(r.Operator, out tBinary))
+            if (Enum.TryParse(r.Operator, out ExpressionType tBinary))
             {
                 var right = System.Linq.Expressions.Expression.Constant(Convert.ChangeType(r.TargetValue, tProp));
                 // use a binary operation, e.g. 'Equal' -> 'u.Age == 15'
@@ -25,7 +24,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
             if (r.Operator == "MatchRegex" || r.Operator == "NotMatchRegex")
             {
                 var regex = new Regex(r.TargetValue);
-                var method = typeof(Regex).GetMethod("IsMatch", new[] {typeof(string)});
+                var method = typeof(Regex).GetMethod("IsMatch", new[] { typeof(string) });
                 Debug.Assert(method != null, nameof(method) + " != null");
                 var callInstance = System.Linq.Expressions.Expression.Constant(regex);
 
@@ -39,14 +38,15 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
             }
 
             if (tProp.Name == "String")
-            { 
-                var method = tProp.GetMethod(r.Operator, new Type[] { typeof(string) });
+            {
+                var method = tProp.GetMethod(r.Operator, new[] { typeof(string) });
                 var tParam = method.GetParameters()[0].ParameterType;
                 var right = System.Linq.Expressions.Expression.Constant(Convert.ChangeType(r.TargetValue, tParam));
                 // use a method call, e.g. 'Contains' -> 'u.Tags.Contains(some_tag)'
                 return System.Linq.Expressions.Expression.Call(left, method, right);
             }
-            else { 
+            else
+            {
                 var method = tProp.GetMethod(r.Operator);
                 var tParam = method.GetParameters()[0].ParameterType;
                 var right = System.Linq.Expressions.Expression.Constant(Convert.ChangeType(r.TargetValue, tParam));
@@ -58,7 +58,7 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
         public static Func<T, bool> CompileRule<T>(Expression r)
         {
             var paramUser = System.Linq.Expressions.Expression.Parameter(typeof(Operand));
-            System.Linq.Expressions.Expression expr = BuildExpr<T>(r, paramUser);
+            var expr = BuildExpr<T>(r, paramUser);
             // build a lambda function User->bool and compile it
             var value = System.Linq.Expressions.Expression.Lambda<Func<T, bool>>(expr, paramUser).Compile(true);
             return value;
@@ -66,31 +66,27 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
 
         public static List<ExpressionSet> FixRuleSets(List<ExpressionSet> rulesets)
         {
-            foreach (var rules in rulesets)
-            {
-                FixRules(rules);
-            }
+            foreach (var rules in rulesets) FixRules(rules);
             return rulesets;
         }
 
         public static ExpressionSet FixRules(ExpressionSet rules)
         {
             foreach (var rule in rules.Expressions)
-            {
                 if (rule.MemberName == "PremiereDate")
                 {
                     var somedate = DateTime.Parse(rule.TargetValue);
                     rule.TargetValue = ConvertToUnixTimestamp(somedate).ToString();
                 }
-            }
+
             return rules;
         }
 
         public static double ConvertToUnixTimestamp(DateTime date)
         {
-            DateTime origin = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-            TimeSpan diff = date.ToUniversalTime() - origin;
+            var origin = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+            var diff = date.ToUniversalTime() - origin;
             return Math.Floor(diff.TotalSeconds);
         }
-    }	
+    }
 }

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Expression.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Expression.cs
@@ -2,14 +2,15 @@
 {
     public class Expression
     {
-        public string MemberName{ get; set; }
+        public Expression(string memberName, string @operator, string targetValue)
+        {
+            MemberName = memberName;
+            Operator = @operator;
+            TargetValue = targetValue;
+        }
+
+        public string MemberName { get; set; }
         public string Operator { get; set; }
         public string TargetValue { get; set; }
-        public Expression(string MemberName, string Operator, string TargetValue)
-        {
-            this.MemberName = MemberName;
-            this.Operator = Operator;
-            this.TargetValue = TargetValue;
-        }
     }
 }

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Factory.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Factory.cs
@@ -1,20 +1,17 @@
-﻿using MediaBrowser.Controller.Entities;
-using System;
-using System.Collections.Generic;
-using Jellyfin.Data.Entities;
+﻿using System;
 using System.Linq;
+using Jellyfin.Data.Entities;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 
 namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
 {
-    class OperandFactory
+    internal class OperandFactory
     {
         // Returns a specific operand povided a baseitem, user, and library manager object.
         public static Operand GetMediaType(ILibraryManager libraryManager, BaseItem baseItem, User user)
         {
-
             var operand = new Operand(baseItem.Name);
-            var directors = new List<string> { };
             var people = libraryManager.GetPeople(baseItem);
             if (people.Any())
             {
@@ -36,14 +33,12 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
             operand.Album = baseItem.Album;
 
             if (baseItem.PremiereDate.HasValue)
-            {
                 operand.PremiereDate = new DateTimeOffset(baseItem.PremiereDate.Value).ToUnixTimeSeconds();
-            }
             operand.DateCreated = new DateTimeOffset(baseItem.DateCreated).ToUnixTimeSeconds();
             operand.DateLastRefreshed = new DateTimeOffset(baseItem.DateLastRefreshed).ToUnixTimeSeconds();
             operand.DateLastSaved = new DateTimeOffset(baseItem.DateLastSaved).ToUnixTimeSeconds();
             operand.DateModified = new DateTimeOffset(baseItem.DateModified).ToUnixTimeSeconds();
-            
+
             operand.FolderPath = baseItem.ContainingFolderPath;
             return operand;
         }

--- a/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Operand.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/QueryEngine/Operand.cs
@@ -4,27 +4,6 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
 {
     public class Operand
     {
-        public List<string> Actors { get; set; }
-        public List<string> Composers { get; set; }
-        public float CommunityRating { get; set; }
-        public float CriticRating { get; set; }
-        public List<string> Directors { get; set; }
-        public List<string> Genres { get; set; }
-        public List<string> GuestStars { get; set; }
-        public bool IsPlayed { get; set; }
-        public string Name { get; set; }
-        public string FolderPath { get; set; }
-        public double PremiereDate { get; set; }
-        public List<string> Producers { get; set; }
-        public List<string> Studios { get; set; }
-        public List<string> Writers { get; set; }
-        public string MediaType { get; set; }
-        public string Album { get; set; }
-        public double DateCreated { get; set; }
-        public double DateLastRefreshed { get; set; }
-        public double DateLastSaved { get; set; }
-        public double DateModified { get; set; }
-
         public Operand(string name)
         {
             Actors = new List<string>();
@@ -47,5 +26,26 @@ namespace Jellyfin.Plugin.SmartPlaylist.QueryEngine
             DateLastSaved = 0;
             DateModified = 0;
         }
+
+        public List<string> Actors { get; set; }
+        public List<string> Composers { get; set; }
+        public float CommunityRating { get; set; }
+        public float CriticRating { get; set; }
+        public List<string> Directors { get; set; }
+        public List<string> Genres { get; set; }
+        public List<string> GuestStars { get; set; }
+        public bool IsPlayed { get; set; }
+        public string Name { get; set; }
+        public string FolderPath { get; set; }
+        public double PremiereDate { get; set; }
+        public List<string> Producers { get; set; }
+        public List<string> Studios { get; set; }
+        public List<string> Writers { get; set; }
+        public string MediaType { get; set; }
+        public string Album { get; set; }
+        public double DateCreated { get; set; }
+        public double DateLastRefreshed { get; set; }
+        public double DateLastSaved { get; set; }
+        public double DateModified { get; set; }
     }
 }

--- a/Jellyfin.Plugin.SmartPlaylist/SmartPlaylist.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/SmartPlaylist.cs
@@ -1,15 +1,46 @@
-﻿using Jellyfin.Data.Entities;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Data.Entities;
 using Jellyfin.Plugin.SmartPlaylist.QueryEngine;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Jellyfin.Plugin.SmartPlaylist
 {
     public class SmartPlaylist
     {
+        public SmartPlaylist(SmartPlaylistDto dto)
+        {
+            Id = dto.Id;
+            Name = dto.Name;
+            FileName = dto.FileName;
+            User = dto.User;
+            ExpressionSets = Engine.FixRuleSets(dto.ExpressionSets);
+            if (dto.MaxItems > 0)
+                MaxItems = dto.MaxItems;
+            else
+                MaxItems = 1000;
+
+            switch (dto.Order.Name)
+            {
+                //ToDo It would be nice to move to automapper and create a better way to map this.
+                // Could also use DefinedLimitOrders from emby version.
+                case "NoOrder":
+                    Order = new NoOrder();
+                    break;
+                case "Release Date Ascending":
+                    Order = new PremiereDateOrder();
+                    break;
+                case "Release Date Descending":
+                    Order = new PremiereDateOrderDesc();
+                    break;
+                default:
+                    Order = new NoOrder();
+                    break;
+            }
+        }
+
         public string Id { get; set; }
         public string Name { get; set; }
         public string FileName { get; set; }
@@ -18,89 +49,56 @@ namespace Jellyfin.Plugin.SmartPlaylist
         public int MaxItems { get; set; }
         public Order Order { get; set; }
 
-        public SmartPlaylist(SmartPlaylistDto dto)
-        {
-            this.Id = dto.Id;
-            this.Name = dto.Name;
-            this.FileName = dto.FileName;
-            this.User = dto.User;
-            this.ExpressionSets = Engine.FixRuleSets(dto.ExpressionSets);
-            if (dto.MaxItems > 0)
-            {
-                this.MaxItems = dto.MaxItems;
-            }
-            else
-            {
-                this.MaxItems = 1000;
-            }
-
-            switch (dto.Order.Name)
-            {
-                //ToDo It would be nice to move to automapper and create a better way to map this.
-                // Could also use DefinedLimitOrders from emby version.
-                case "NoOrder":
-                    this.Order = new NoOrder();
-                    break;
-                case "Release Date Ascending":
-                    this.Order = new PremiereDateOrder();
-                    break;
-                case "Release Date Descending":
-                    this.Order = new PremiereDateOrderDesc();
-                    break;
-                default:
-                    this.Order = new NoOrder();
-                    break;
-            }
-            
-        }
         private List<List<Func<Operand, bool>>> CompileRuleSets()
         {
-
-            List<List<Func<Operand, bool>>> compiledRuleSets = new List<List<Func<Operand, bool>>>();
-            foreach(var set in this.ExpressionSets)
-            {
+            var compiledRuleSets = new List<List<Func<Operand, bool>>>();
+            foreach (var set in ExpressionSets)
                 compiledRuleSets.Add(set.Expressions.Select(r => Engine.CompileRule<Operand>(r)).ToList());
-            }
             return compiledRuleSets;
         }
+
         // Returns the ID's of the items, if order is provided the IDs are sorted.
-        public IEnumerable<Guid> FilterPlaylistItems(IEnumerable<BaseItem> items, ILibraryManager libraryManager, User user)
+        public IEnumerable<Guid> FilterPlaylistItems(IEnumerable<BaseItem> items, ILibraryManager libraryManager,
+            User user)
         {
-            var results = new List<BaseItem> { };
+            var results = new List<BaseItem>();
 
             var compiledRules = CompileRuleSets();
             foreach (var i in items)
             {
                 var operand = OperandFactory.GetMediaType(libraryManager, i, user);
-                
-                if (compiledRules.Any(set => set.All(rule => rule(operand))))
-                {
-                    results.Add(i);
-                }
+
+                if (compiledRules.Any(set => set.All(rule => rule(operand)))) results.Add(i);
             }
+
             return Order.OrderBy(results).Select(x => x.Id);
         }
+
         private static void Validate()
         {
             //Todo create validation for constructor
         }
     }
+
     public abstract class Order
     {
         public abstract string Name { get; }
+
         public virtual IEnumerable<BaseItem> OrderBy(IEnumerable<BaseItem> items)
         {
             return items;
         }
     }
-    public class NoOrder: Order
+
+    public class NoOrder : Order
     {
         public override string Name => "NoOrder";
-
     }
+
     public class PremiereDateOrder : Order
     {
         public override string Name => "Release Date Ascending";
+
         public override IEnumerable<BaseItem> OrderBy(IEnumerable<BaseItem> items)
         {
             return items.OrderBy(x => x.PremiereDate);
@@ -110,6 +108,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
     public class PremiereDateOrderDesc : Order
     {
         public override string Name => "Release Date Descending";
+
         public override IEnumerable<BaseItem> OrderBy(IEnumerable<BaseItem> items)
         {
             return items.OrderByDescending(x => x.PremiereDate);

--- a/Jellyfin.Plugin.SmartPlaylist/SmartPlaylistDto.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/SmartPlaylistDto.cs
@@ -1,6 +1,6 @@
-﻿using Jellyfin.Plugin.SmartPlaylist.QueryEngine;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using Jellyfin.Plugin.SmartPlaylist.QueryEngine;
 
 namespace Jellyfin.Plugin.SmartPlaylist
 {
@@ -11,14 +11,16 @@ namespace Jellyfin.Plugin.SmartPlaylist
         public string Name { get; set; }
         public string FileName { get; set; }
         public string User { get; set; }
-        public List<ExpressionSet> ExpressionSets{ get; set; }
+        public List<ExpressionSet> ExpressionSets { get; set; }
         public int MaxItems { get; set; }
         public OrderDto Order { get; set; }
     }
+
     public class ExpressionSet
     {
         public List<Expression> Expressions { get; set; }
     }
+
     public class OrderDto
     {
         public string Name { get; set; }

--- a/Jellyfin.Plugin.SmartPlaylist/SmartPlaylistFileSystem.cs
+++ b/Jellyfin.Plugin.SmartPlaylist/SmartPlaylistFileSystem.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using MediaBrowser.Controller;
 
@@ -13,6 +12,7 @@ namespace Jellyfin.Plugin.SmartPlaylist
         string[] GetAllSmartPlaylistFilePaths();
         string GetSmartPlaylistPath(string userId, string playlistId);
     }
+
     public class SmartPlaylistFileSystem : ISmartPlaylistFileSystem
     {
         // Class Constructor for SmartPlaylistFileSystem

--- a/Tests/SmartPlaylistTest.cs
+++ b/Tests/SmartPlaylistTest.cs
@@ -1,8 +1,7 @@
-using System;
-using Xunit;
+using System.Collections.Generic;
 using Jellyfin.Plugin.SmartPlaylist;
 using Jellyfin.Plugin.SmartPlaylist.QueryEngine;
-using System.Collections.Generic;
+using Xunit;
 
 namespace Tests
 {
@@ -11,15 +10,19 @@ namespace Tests
         [Fact]
         public void DtoToSmartPlaylist()
         {
-            var dto = new SmartPlaylistDto();
-            dto.Id = "87ccaa10-f801-4a7a-be40-46ede34adb22";
-            dto.Name = "Foo";
-            dto.User = "Rob";
-            
-            var es = new ExpressionSet();
-            es.Expressions = new List<Expression>
+            var dto = new SmartPlaylistDto
             {
-                new Expression("foo", "bar", "biz")
+                Id = "87ccaa10-f801-4a7a-be40-46ede34adb22",
+                Name = "Foo",
+                User = "Rob"
+            };
+
+            var es = new ExpressionSet
+            {
+                Expressions = new List<Expression>
+                {
+                    new("foo", "bar", "biz")
+                }
             };
             dto.ExpressionSets = new List<ExpressionSet>
             {
@@ -29,16 +32,16 @@ namespace Tests
             {
                 Name = "Release Date Descending"
             };
-            SmartPlaylist smart_playlist = new SmartPlaylist(dto);
+            var smartPlaylist = new SmartPlaylist(dto);
 
-            Assert.Equal(1000, smart_playlist.MaxItems);
-            Assert.Equal("87ccaa10-f801-4a7a-be40-46ede34adb22", smart_playlist.Id);
-            Assert.Equal("Foo", smart_playlist.Name);
-            Assert.Equal("Rob", smart_playlist.User);
-            Assert.Equal("foo", smart_playlist.ExpressionSets[0].Expressions[0].MemberName);
-            Assert.Equal("bar",smart_playlist.ExpressionSets[0].Expressions[0].Operator);
-            Assert.Equal("biz",smart_playlist.ExpressionSets[0].Expressions[0].TargetValue);
-            Assert.Equal("PremiereDateOrderDesc", smart_playlist.Order.GetType().Name);
+            Assert.Equal(1000, smartPlaylist.MaxItems);
+            Assert.Equal("87ccaa10-f801-4a7a-be40-46ede34adb22", smartPlaylist.Id);
+            Assert.Equal("Foo", smartPlaylist.Name);
+            Assert.Equal("Rob", smartPlaylist.User);
+            Assert.Equal("foo", smartPlaylist.ExpressionSets[0].Expressions[0].MemberName);
+            Assert.Equal("bar", smartPlaylist.ExpressionSets[0].Expressions[0].Operator);
+            Assert.Equal("biz", smartPlaylist.ExpressionSets[0].Expressions[0].TargetValue);
+            Assert.Equal("PremiereDateOrderDesc", smartPlaylist.Order.GetType().Name);
         }
     }
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,20 +1,26 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.1.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Jellyfin.Plugin.SmartPlaylist\Jellyfin.Plugin.SmartPlaylist.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Jellyfin.Plugin.SmartPlaylist\Jellyfin.Plugin.SmartPlaylist.csproj" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Remove `JSONSerializer` which is no longer available. Replace it with dotnet built-in JSON Serializer.
- Change `InternalItemsQuery.IncludeItemTypes` parameter to `BaseItemKind[]`.
- Whole project code format / cleanup.